### PR TITLE
release(v1.6.2): automate merge-time release tagging and align release notes

### DIFF
--- a/.github/workflows/tag-release-merge.yml
+++ b/.github/workflows/tag-release-merge.yml
@@ -1,0 +1,77 @@
+name: Tag Release Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  tag_release_merge:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      startsWith(github.event.pull_request.head.ref, 'dev/v') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract release version from branch
+        id: release
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${HEAD_REF}" =~ ^dev/v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "::notice::Skip tagging: '${HEAD_REF}' is not in dev/vX.Y.Z format."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ -z "${MERGE_SHA}" ]]; then
+            echo "::error::Missing merge_commit_sha for merged PR."
+            exit 1
+          fi
+
+          version="${BASH_REMATCH[1]}"
+          tag="v${version}"
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "merge_sha=${MERGE_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout main
+        if: steps.release.outputs.skip != 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Create and push release tag
+        if: steps.release.outputs.skip != 'true'
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag }}
+          MERGE_SHA: ${{ steps.release.outputs.merge_sha }}
+        run: |
+          set -euo pipefail
+
+          # If tag exists locally (fetched from origin), ensure it points to this merge commit.
+          if git rev-parse -q --verify "refs/tags/${TAG_NAME}" >/dev/null; then
+            existing_sha="$(git rev-list -n 1 "${TAG_NAME}")"
+            if [[ "${existing_sha}" == "${MERGE_SHA}" ]]; then
+              echo "::notice::Tag ${TAG_NAME} already exists at ${MERGE_SHA}; nothing to do."
+              exit 0
+            fi
+            echo "::error::Tag ${TAG_NAME} already exists at ${existing_sha}, expected ${MERGE_SHA}."
+            exit 1
+          fi
+
+          git tag "${TAG_NAME}" "${MERGE_SHA}"
+          git push origin "refs/tags/${TAG_NAME}"
+          echo "Tagged ${TAG_NAME} at ${MERGE_SHA}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+## [v1.6.2] - 2026-03-11
+
+### Fixed
+- `scripts/new_release_branch.py` now defaults to creating only `dev/vX.Y.Z` branches (with optional `--tag-now` legacy behavior), and a new GitHub Action tags merged `dev/vX.Y.Z` PRs on `main` at the merge commit so release tags reflect shipped code (`scripts/new_release_branch.py`, `.github/workflows/tag-release-merge.yml`).
+
+---
+
 ## [v1.6.1] - 2026-03-11
 
 ### Fixed
@@ -12,7 +19,6 @@
 - Upgraded frontend security-sensitive dependencies (`next` to `15.5.12`, `eslint-config-next` to `15.5.12`, `react-markdown` to `10.1.0`) and pinned `mdast-util-to-hast@13.2.1` via `overrides` to clear audit findings (`web/package.json`, `web/package-lock.json`).
 - Updated the Next.js catch-all API route context typing for Next 15 route type generation compatibility (`web/src/app/api/[...all]/route.ts`, `web/next-env.d.ts`).
 - Replaced the homepage bottles navigation anchor with `next/link` so Next.js lint/type checks pass during production image builds (`web/src/app/page.tsx`).
-- `scripts/new_release_branch.py` now defaults to creating only `dev/vX.Y.Z` branches (with optional `--tag-now` legacy behavior), and a new GitHub Action tags merged `dev/vX.Y.Z` PRs on `main` at the merge commit so release tags reflect shipped code (`scripts/new_release_branch.py`, `.github/workflows/tag-release-merge.yml`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Upgraded frontend security-sensitive dependencies (`next` to `15.5.12`, `eslint-config-next` to `15.5.12`, `react-markdown` to `10.1.0`) and pinned `mdast-util-to-hast@13.2.1` via `overrides` to clear audit findings (`web/package.json`, `web/package-lock.json`).
 - Updated the Next.js catch-all API route context typing for Next 15 route type generation compatibility (`web/src/app/api/[...all]/route.ts`, `web/next-env.d.ts`).
 - Replaced the homepage bottles navigation anchor with `next/link` so Next.js lint/type checks pass during production image builds (`web/src/app/page.tsx`).
+- `scripts/new_release_branch.py` now defaults to creating only `dev/vX.Y.Z` branches (with optional `--tag-now` legacy behavior), and a new GitHub Action tags merged `dev/vX.Y.Z` PRs on `main` at the merge commit so release tags reflect shipped code (`scripts/new_release_branch.py`, `.github/workflows/tag-release-merge.yml`).
 
 ---
 

--- a/scripts/new_release_branch.py
+++ b/scripts/new_release_branch.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Automate branch + tag creation for new versions.
+"""Automate release branch creation for new versions.
 
 Workflow:
 1. Verify clean working tree.
 2. Switch to main, fetch, and fast-forward from origin.
 3. Prompt for a semantic version (e.g., 1.2.7).
 4. Create `dev/v<version>` from main and push to origin.
-5. Tag the same commit as `v<version>` and push the tag.
+5. Optionally tag the same commit as `v<version>` and push the tag (`--tag-now`).
 6. Checkout the new branch so you can continue working there.
 
 No changes are made if any step fails.
@@ -146,11 +146,18 @@ def remove_stale_dev_branches(*, keep: set[str]) -> None:
         print(f"🧹 Removed stale local branch {branch}")
 
 
-def prompt_version() -> str:
-    parser = argparse.ArgumentParser(description="Create dev/vX.Y.Z branch and vX.Y.Z tag")
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create dev/vX.Y.Z release branch (optionally tag now)")
     parser.add_argument("version", nargs="?", help="Semantic version like 1.2.7")
-    args = parser.parse_args()
-    version = args.version
+    parser.add_argument(
+        "--tag-now",
+        action="store_true",
+        help="Create and push vX.Y.Z immediately from main (legacy behavior).",
+    )
+    return parser.parse_args()
+
+
+def prompt_version(version: str | None) -> str:
     if not version:
         try:
             version = input("Enter release version (e.g. 1.2.7): ").strip()
@@ -177,13 +184,17 @@ def create_branch(branch: str) -> None:
     run([GIT, "push", "-u", "origin", branch])
 
 
-def create_tag(tag: str) -> None:
-    run([GIT, "checkout", "main"])
-    run([GIT, "tag", tag])
+def create_tag(tag: str, *, target_ref: str = "main") -> None:
+    run([GIT, "tag", tag, target_ref])
     run([GIT, "push", "origin", tag])
 
 
 def main() -> None:
+    args = parse_args()
+    version = prompt_version(args.version)
+    branch = f"dev/v{version}"
+    tag = f"v{version}"
+
     start_ssh_agent()
     ensure_clean_worktree()
     repo_root = get_repo_root()
@@ -192,15 +203,20 @@ def main() -> None:
         checkout_main()
         fast_forward_main()
         remove_stale_dev_branches(keep={"main"})
-        version = prompt_version()
-        branch = f"dev/v{version}"
-        tag = f"v{version}"
         ensure_ref_absent(branch, ref_type="Branch")
         ensure_ref_absent(tag, ref_type="Tag")
         create_branch(branch)
-        create_tag(tag)
+        if args.tag_now:
+            create_tag(tag, target_ref="main")
         run([GIT, "checkout", branch])
-        print(f"✅ Created branch {branch} and tag {tag}. You're now on {branch}.")
+        if args.tag_now:
+            print(f"✅ Created branch {branch} and tag {tag}. You're now on {branch}.")
+        else:
+            print(f"✅ Created branch {branch}. You're now on {branch}.")
+            print(
+                "ℹ️ Tag creation is deferred. Merge this branch into main to let CI tag the merge commit as "
+                f"{tag}."
+            )
         run([GIT, "fetch", "origin", "--prune"])
         branches = run([GIT, "branch", "-a"], capture_output=True)
         print(branches.stdout.rstrip())


### PR DESCRIPTION
## Summary

- Updated scripts/new_release_branch.py to default to branch-only creation (dev/vX.Y.Z) without creating tags.
- Added explicit legacy override --tag-now for manual immediate tagging when needed.
- Added .github/workflows/tag-release-merge.yml to auto-tag merged release PRs:
- Runs on merged PRs into main
- Requires source branch format dev/vX.Y.Z
- Creates tag vX.Y.Z at the PR merge commit SHA
- Fails safely if the tag already exists on a different commit
