### PR TITLE
feat: add automatic admin bootstrap and admin session indicator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,7 +69,7 @@ LOG_RETENTION_DAYS=14
 UPLOAD_MAX_MB=100
 UPLOAD_DIR=/data/uploads
 
-# --- Admin bootstrap (one-time) ---
+# --- Admin bootstrap (auto-creates on first startup if missing) ---
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=please-change-me
 ADMIN_EMAIL=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - App startup now auto-creates the configured admin user from `ADMIN_USERNAME` / `ADMIN_PASSWORD` on first startup when that username is missing from the database, removing the need to run `python -m app.bootstrap_admin` manually on fresh deployments while preserving existing accounts (`api/app/bootstrap_admin.py`, `api/app/main.py`, `api/tests/test_admin_users.py`, `.env.example`, `README.md`).
 
 ### Changed
-- The `Admin` navigation link now gets a subtle glow when the current session is actively authenticated as an admin, making it clearer that you are already signed in with admin access (`web/src/components/NavLinks.tsx`, `web/src/app/global.css`).
+- The right-side `Admin` header button now gets a subtle glow when the current session is actively authenticated as an admin, making it clearer that you are already signed in with admin access (`web/src/components/HeaderAuthControl.tsx`, `web/src/app/global.css`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+## [v1.6.3] - 2026-03-13
+
+### Added
+- App startup now auto-creates the configured admin user from `ADMIN_USERNAME` / `ADMIN_PASSWORD` on first startup when that username is missing from the database, removing the need to run `python -m app.bootstrap_admin` manually on fresh deployments while preserving existing accounts (`api/app/bootstrap_admin.py`, `api/app/main.py`, `api/tests/test_admin_users.py`, `.env.example`, `README.md`).
+
+---
+
 ## [v1.6.2] - 2026-03-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 - App startup now auto-creates the configured admin user from `ADMIN_USERNAME` / `ADMIN_PASSWORD` on first startup when that username is missing from the database, removing the need to run `python -m app.bootstrap_admin` manually on fresh deployments while preserving existing accounts (`api/app/bootstrap_admin.py`, `api/app/main.py`, `api/tests/test_admin_users.py`, `.env.example`, `README.md`).
 
+### Changed
+- The `Admin` navigation link now gets a subtle glow when the current session is actively authenticated as an admin, making it clearer that you are already signed in with admin access (`web/src/components/NavLinks.tsx`, `web/src/app/global.css`).
+
 ---
 
 ## [v1.6.2] - 2026-03-11

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Access:
 
 #### Admin Console
 - Visit `/admin` (link in the top navigation when signed in) to reach operational tools.
+- On a fresh deployment, setting `ADMIN_USERNAME` and `ADMIN_PASSWORD` in `.env` will auto-create that admin user on first startup if it is not already present. Existing users are left unchanged.
 - The **User management** section lets administrators invite new users, toggle roles, activate/deactivate accounts, and issue password resets. All passwords are hashed with Argon2 before storage.
 - The **Market prices** page records manual price uploads, triggers one-off provider syncs, lets you adjust the latest stored valuation, and lists the freshest price per UPC. Configure external lookups with `MARKET_PRICE_PROVIDER_URL` (supports `{upc}` templating), optional `MARKET_PRICE_PROVIDER_API_KEY`, `MARKET_PRICE_PROVIDER_NAME`, and `MARKET_PRICE_PROVIDER_TIMEOUT_SECONDS`. See `.env.example` for sample values.
 - The **Modules** panel lets admins enable optional areas like Wine; enabled modules appear in the top navigation.

--- a/api/app/bootstrap_admin.py
+++ b/api/app/bootstrap_admin.py
@@ -20,34 +20,63 @@ from .settings import settings
 from .security import hash_password
 
 
-def main() -> int:
-    # Ensure tables exist
-    init_db()
+def ensure_admin_user(
+    session: Session,
+    *,
+    username: str,
+    password: str,
+    email: str | None = None,
+) -> tuple[bool, str]:
+    existing = session.exec(select(User).where(User.username == username)).first()
+    if existing:
+        return False, f"INFO: Admin user already exists: {username}"
 
-    # Validate env
-    if not settings.ADMIN_USERNAME or not settings.ADMIN_PASSWORD:
+    user = User(
+        username=username,
+        email=email,
+        password_hash=hash_password(password),
+        role="admin",
+        is_active=True,
+    )
+    session.add(user)
+    session.commit()
+    return True, f"OK: Admin user created: {username}"
+
+
+def bootstrap_admin_from_settings(*, initialize_db: bool = True, startup: bool = False) -> int:
+    if initialize_db:
+        init_db()
+
+    username = (settings.ADMIN_USERNAME or "").strip()
+    password = settings.ADMIN_PASSWORD or ""
+    email = getattr(settings, "ADMIN_EMAIL", None) or None
+
+    if not username:
+        if startup:
+            return 0
+        print("ERROR: Set ADMIN_USERNAME and ADMIN_PASSWORD in your top-level .env")
+        return 1
+
+    if not password:
+        if startup:
+            print("WARN: ADMIN_USERNAME is set but ADMIN_PASSWORD is empty; skipping admin bootstrap.")
+            return 0
         print("ERROR: Set ADMIN_USERNAME and ADMIN_PASSWORD in your top-level .env")
         return 1
 
     with Session(engine) as session:
-        # Does a user with this username already exist?
-        existing = session.exec(select(User).where(User.username == settings.ADMIN_USERNAME)).first()
-        if existing:
-            print(f"INFO: Admin user already exists: {settings.ADMIN_USERNAME}")
-            return 0
-
-        user = User(
-            username=settings.ADMIN_USERNAME,
-            email=getattr(settings, "ADMIN_EMAIL", None),  # optional
-            password_hash=hash_password(settings.ADMIN_PASSWORD),
-            role="admin",
-            is_active=True,
+        _, message = ensure_admin_user(
+            session,
+            username=username,
+            password=password,
+            email=email,
         )
-        session.add(user)
-        session.commit()
-        print(f"OK: Admin user created: {settings.ADMIN_USERNAME}")
-
+    print(message)
     return 0
+
+
+def main() -> int:
+    return bootstrap_admin_from_settings()
 
 
 if __name__ == "__main__":

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
+from .bootstrap_admin import bootstrap_admin_from_settings
 from .db import init_db
 from .routers import auth, bottles, purchases, notes, retailers, valuation, modules, wine
 from .routers.admin_prices import router as admin_prices_router
@@ -17,6 +18,7 @@ from .version import resolve_version_display
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     init_db()
+    bootstrap_admin_from_settings(initialize_db=False, startup=True)
     yield
 
 

--- a/api/tests/test_admin_users.py
+++ b/api/tests/test_admin_users.py
@@ -32,6 +32,7 @@ init_db = db_module.init_db
 
 app = importlib.import_module("app.main").app
 User = importlib.import_module("app.models").User
+ensure_admin_user = importlib.import_module("app.bootstrap_admin").ensure_admin_user
 hash_password = importlib.import_module("app.security").hash_password
 verify_password = importlib.import_module("app.security").verify_password
 
@@ -177,3 +178,52 @@ def test_verify_password_supports_legacy_bcrypt_hashes():
     # Historical bcrypt variants can be stored as $2y$ in older datasets.
     legacy_2y = "$2y$" + hashed[4:]
     assert verify_password(plain, legacy_2y)
+
+
+def test_ensure_admin_user_creates_missing_admin():
+    init_db()
+    with Session(engine) as session:
+        created, message = ensure_admin_user(
+            session,
+            username="bootstrap-admin",
+            password="BootstrapPass123!",
+            email="bootstrap@example.com",
+        )
+
+    assert created is True
+    assert message == "OK: Admin user created: bootstrap-admin"
+
+    with Session(engine) as session:
+        user = session.exec(select(User).where(User.username == "bootstrap-admin")).first()
+        assert user is not None
+        assert user.role == "admin"
+        assert user.is_active is True
+        assert user.email == "bootstrap@example.com"
+        assert verify_password("BootstrapPass123!", user.password_hash)
+
+
+def test_ensure_admin_user_preserves_existing_admin():
+    init_db()
+    bootstrap_admin(username="existing-admin", password="ExistingPass123!")
+
+    with Session(engine) as session:
+        existing = session.exec(select(User).where(User.username == "existing-admin")).first()
+        assert existing is not None
+        original_hash = existing.password_hash
+
+    with Session(engine) as session:
+        created, message = ensure_admin_user(
+            session,
+            username="existing-admin",
+            password="ReplacementPass123!",
+            email="replacement@example.com",
+        )
+
+    assert created is False
+    assert message == "INFO: Admin user already exists: existing-admin"
+
+    with Session(engine) as session:
+        existing = session.exec(select(User).where(User.username == "existing-admin")).first()
+        assert existing is not None
+        assert existing.password_hash == original_hash
+        assert verify_password("ExistingPass123!", existing.password_hash)

--- a/web/src/app/global.css
+++ b/web/src/app/global.css
@@ -37,6 +37,27 @@ a:hover { text-decoration: underline; }
   position: sticky; top: 0; background: var(--bg); z-index: 1;
 }
 
+.nav-admin-link {
+  border-radius: 999px;
+  padding: 4px 10px;
+  transition: box-shadow 180ms ease, background-color 180ms ease, color 180ms ease;
+}
+
+.nav-admin-link-live {
+  background: color-mix(in srgb, var(--link) 12%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--link) 35%, transparent),
+    0 0 14px color-mix(in srgb, var(--link) 28%, transparent);
+  text-shadow: 0 0 10px color-mix(in srgb, var(--link) 20%, transparent);
+}
+
+.nav-admin-link-live:hover {
+  text-decoration: none;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--link) 50%, transparent),
+    0 0 18px color-mix(in srgb, var(--link) 40%, transparent);
+}
+
 .nav-right { 
   display: flex; align-items: center; gap: 8px; 
 }

--- a/web/src/app/global.css
+++ b/web/src/app/global.css
@@ -37,22 +37,19 @@ a:hover { text-decoration: underline; }
   position: sticky; top: 0; background: var(--bg); z-index: 1;
 }
 
-.nav-admin-link {
-  border-radius: 999px;
-  padding: 4px 10px;
+.header-admin-button {
   transition: box-shadow 180ms ease, background-color 180ms ease, color 180ms ease;
 }
 
-.nav-admin-link-live {
-  background: color-mix(in srgb, var(--link) 12%, transparent);
+.header-admin-button-live {
+  background: color-mix(in srgb, var(--link) 12%, var(--bg));
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--link) 35%, transparent),
     0 0 14px color-mix(in srgb, var(--link) 28%, transparent);
   text-shadow: 0 0 10px color-mix(in srgb, var(--link) 20%, transparent);
 }
 
-.nav-admin-link-live:hover {
-  text-decoration: none;
+.header-admin-button-live:hover {
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--link) 50%, transparent),
     0 0 18px color-mix(in srgb, var(--link) 40%, transparent);

--- a/web/src/components/HeaderAuthControl.tsx
+++ b/web/src/components/HeaderAuthControl.tsx
@@ -36,6 +36,10 @@ export default function HeaderAuthControl() {
   if (!user) return null;
 
   const isAuthenticated = user.authenticated;
+  const adminGlow =
+    isAuthenticated && user.role === 'admin'
+      ? 'header-admin-button header-admin-button-live'
+      : 'header-admin-button';
 
   // Tell the entire app that auth changed
   const notifyAuthChanged = () => {
@@ -82,7 +86,7 @@ export default function HeaderAuthControl() {
 
   return (
     <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-      <button onClick={() => setOpen((v) => !v)}>Admin</button>
+      <button className={adminGlow} onClick={() => setOpen((v) => !v)}>Admin</button>
       {isAuthenticated && (
         <button onClick={doLogout} style={{ marginLeft: 4 }}>
           Logout

--- a/web/src/components/NavLinks.tsx
+++ b/web/src/components/NavLinks.tsx
@@ -5,9 +5,8 @@ import { useMe } from '../lib/useMe';
 import { useModules } from '../lib/useModules';
 
 export default function NavLinks() {
-  const { isAdmin, me } = useMe();
+  const { isAdmin } = useMe();
   const { modules } = useModules();
-  const adminGlow = isAdmin && me.authenticated ? 'nav-admin-link nav-admin-link-live' : 'nav-admin-link';
 
   return (
     <>
@@ -16,7 +15,7 @@ export default function NavLinks() {
       {modules.wine && <Link href="/wine">Wine</Link>}
       {isAdmin && (
         <>
-          <Link href="/admin" className={adminGlow}>Admin</Link>
+          <Link href="/admin">Admin</Link>
           <Link href="/security">Account</Link>
         </>
       )}

--- a/web/src/components/NavLinks.tsx
+++ b/web/src/components/NavLinks.tsx
@@ -7,6 +7,7 @@ import { useModules } from '../lib/useModules';
 export default function NavLinks() {
   const { isAdmin, me } = useMe();
   const { modules } = useModules();
+  const adminGlow = isAdmin && me.authenticated ? 'nav-admin-link nav-admin-link-live' : 'nav-admin-link';
 
   return (
     <>
@@ -15,7 +16,7 @@ export default function NavLinks() {
       {modules.wine && <Link href="/wine">Wine</Link>}
       {isAdmin && (
         <>
-          <Link href="/admin">Admin</Link>
+          <Link href="/admin" className={adminGlow}>Admin</Link>
           <Link href="/security">Account</Link>
         </>
       )}


### PR DESCRIPTION
## Summary
- Auto-create the configured admin user from `ADMIN_USERNAME` / `ADMIN_PASSWORD` on first startup when that username is missing from the database.
- Remove the need to manually run `python -m app.bootstrap_admin` for fresh deployments while preserving existing accounts.
- Add a subtle authenticated-admin glow to the right-side `Admin` header button so active admin sessions are easier to identify.

## Testing
- Added/updated admin bootstrap coverage in `api/tests/test_admin_users.py`.